### PR TITLE
Use `path_url` across all files

### DIFF
--- a/check_process
+++ b/check_process
@@ -2,7 +2,7 @@
 	auto_remove=1
 	; Manifest
 		domain="domain.tld"	(DOMAIN)
-		path="/path"	(PATH)
+		path_url="/path"	(PATH)
 		admin="john"	(USER)
 		language="fr_FR"
 		is_public=1	(PUBLIC|public=1|private=0)

--- a/manifest.json
+++ b/manifest.json
@@ -31,8 +31,8 @@
                 "example": "domain.org"
             },
             {
-                "name": "path",
-                "type": "path",
+                "name": "path_url",
+                "type": "path_url",
                 "ask": {
                     "en": "Choose a path for umap",
                     "fr": "Choisissez un chemin pour umap"

--- a/scripts/install
+++ b/scripts/install
@@ -15,7 +15,7 @@ TRAP_ON	# Active trap to stop the script if an error is detected.
 
 # Retrieve arguments
 domain=$YNH_APP_ARG_DOMAIN
-path=$YNH_APP_ARG_PATH
+path_url=$YNH_APP_ARG_PATH_URL
 admin=$YNH_APP_ARG_ADMIN
 language=$YNH_APP_ARG_LANGUAGE
 is_public=$YNH_APP_ARG_IS_PUBLIC
@@ -43,7 +43,7 @@ CHECK_FINALPATH	# Chech destination directory is not exist.
 
 # Save app settings
 ynh_app_setting_set $app domain $domain
-ynh_app_setting_set $app path $path
+ynh_app_setting_set $app path $path_url
 ynh_app_setting_set $app admin $admin
 ynh_app_setting_set $app language $language
 ynh_app_setting_set $app is_public $is_public

--- a/scripts/restore
+++ b/scripts/restore
@@ -18,12 +18,12 @@ app=$YNH_APP_INSTANCE_NAME
 
 # Get old parameter of the app
 domain=$(ynh_app_setting_get $app domain)
-path=$(ynh_app_setting_get $app path)
+path_url=$(ynh_app_setting_get $app path_url)
 is_public=$(ynh_app_setting_get $app is_public)
 
 # Check domain/path availability
-sudo yunohost app checkurl "${domain}${path}" -a "$app" \
-    || ynh_die "Path not available: ${domain}${path}"
+sudo yunohost app checkurl "${domain}${path_url}" -a "$app" \
+    || ynh_die "Path not available: ${domain}${path_url}"
 
 # Check $final_path
 final_path="/opt/${app}"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -18,7 +18,7 @@ app=$YNH_APP_INSTANCE_NAME
 
 # Retrieve app settings
 domain=$(ynh_app_setting_get "$app" domain)
-path=$(ynh_app_setting_get "$app" path)
+path_url=$(ynh_app_setting_get "$app" path_url)
 admin=$(ynh_app_setting_get "$app" admin)
 language=$(ynh_app_setting_get "$app" language)
 


### PR DESCRIPTION
This resolves the failure I am seeing:

```
Warning: ./install: line 48: path_url: unbound variable
Warning: [ERR] !!
Warning:   umap's script has encountered an error. Its execution was cancelled.
Warning: !!
```