### PR TITLE
Use ynh_replace_string instead of ynh_substitute_char

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -15,50 +15,50 @@ ynh_psql_create_extension() {
 #
 ynh_replace_config_umap() {
 	if test -n "${admin:-}"; then
-		ynh_substitute_char "You" "$admin" "$localfile"
-		ynh_substitute_char "your@email" "$admin@$domain" "$localfile"
+		ynh_replace_string "You" "$admin" "$localfile"
+		ynh_replace_string "your@email" "$admin@$domain" "$localfile"
 	fi
 	if test -n "${secret:-}"; then
-		ynh_substitute_char "SECRET_KEY = '!!change me!!'" "SECRET_KEY = '$secret'" "$localfile"
+		ynh_replace_string "SECRET_KEY = '!!change me!!'" "SECRET_KEY = '$secret'" "$localfile"
 	fi
 	if test -n "${final_path:-}"; then
-		ynh_substitute_char "STATIC_ROOT = '/home/srv/var/static'" "STATIC_ROOT = '$final_path/static'" "$localfile"
-		ynh_substitute_char "MEDIA_ROOT = '/home/srv/umap/var/data'" "MEDIA_ROOT = '$final_path/data'" "$localfile"
+		ynh_replace_string "STATIC_ROOT = '/home/srv/var/static'" "STATIC_ROOT = '$final_path/static'" "$localfile"
+		ynh_replace_string "MEDIA_ROOT = '/home/srv/umap/var/data'" "MEDIA_ROOT = '$final_path/data'" "$localfile"
 	fi
 	if test -n "${language:-}"; then
-		ynh_substitute_char "LANGUAGE_CODE = 'en'" "LANGUAGE_CODE = '$language'" "$localfile"
+		ynh_replace_string "LANGUAGE_CODE = 'en'" "LANGUAGE_CODE = '$language'" "$localfile"
 	fi
-	ynh_substitute_char "UMAP_DEMO_SITE = True" "UMAP_DEMO_SITE = False" "$localfile"
+	ynh_replace_string "UMAP_DEMO_SITE = True" "UMAP_DEMO_SITE = False" "$localfile"
 
 	# Replace variable for Oauth providers
 	if test -n "${github_key:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_GITHUB_KEY = 'xxx'" "SOCIAL_AUTH_GITHUB_KEY = '$github_key'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_GITHUB_KEY = 'xxx'" "SOCIAL_AUTH_GITHUB_KEY = '$github_key'" "$localfile"
 	fi
 	if test -n "${github_secret:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_GITHUB_SECRET = 'xxx'" "SOCIAL_AUTH_GITHUB_SECRET = '$github_secret'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_GITHUB_SECRET = 'xxx'" "SOCIAL_AUTH_GITHUB_SECRET = '$github_secret'" "$localfile"
 	fi
 	if test -n "${github_scope:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_GITHUB_SCOPE = [\"user:email\", ]" "SOCIAL_AUTH_GITHUB_SCOPE = $github_scope" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_GITHUB_SCOPE = [\"user:email\", ]" "SOCIAL_AUTH_GITHUB_SCOPE = $github_scope" "$localfile"
 	fi
 
 	if test -n "${bitbucket_key:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_BITBUCKET_KEY = 'xxx'" "SOCIAL_AUTH_BITBUCKET_KEY = '$bitbucket_key'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_BITBUCKET_KEY = 'xxx'" "SOCIAL_AUTH_BITBUCKET_KEY = '$bitbucket_key'" "$localfile"
 	fi
 	if test -n "${bitbucket_secret:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_BITBUCKET_SECRET = 'xxx'" "SOCIAL_AUTH_BITBUCKET_SECRET = '$bitbucket_secret'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_BITBUCKET_SECRET = 'xxx'" "SOCIAL_AUTH_BITBUCKET_SECRET = '$bitbucket_secret'" "$localfile"
 	fi
 
 	if test -n "${twitter_key:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_TWITTER_KEY = 'xxx'" "SOCIAL_AUTH_TWITTER_KEY = '$twitter_key'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_TWITTER_KEY = 'xxx'" "SOCIAL_AUTH_TWITTER_KEY = '$twitter_key'" "$localfile"
 	fi
 	if test -n "${twitter_secret:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_TWITTER_SECRET = 'xxx'" "SOCIAL_AUTH_TWITTER_SECRET = '$twitter_secret'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_TWITTER_SECRET = 'xxx'" "SOCIAL_AUTH_TWITTER_SECRET = '$twitter_secret'" "$localfile"
 	fi
 
 	if test -n "${openstreetmap_key:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_OPENSTREETMAP_KEY = 'xxx'" "SOCIAL_AUTH_OPENSTREETMAP_KEY = '$openstreetmap_key'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_OPENSTREETMAP_KEY = 'xxx'" "SOCIAL_AUTH_OPENSTREETMAP_KEY = '$openstreetmap_key'" "$localfile"
 	fi
 	if test -n "${openstreetmap_secret:-}"; then
-		ynh_substitute_char "SOCIAL_AUTH_OPENSTREETMAP_SECRET = 'xxx'" "SOCIAL_AUTH_OPENSTREETMAP_SECRET = '$openstreetmap_secret'" "$localfile"
+		ynh_replace_string "SOCIAL_AUTH_OPENSTREETMAP_SECRET = 'xxx'" "SOCIAL_AUTH_OPENSTREETMAP_SECRET = '$openstreetmap_secret'" "$localfile"
 	fi
 }


### PR DESCRIPTION
Guessing from https://yunohost.org/#/packaging_apps_helpers_en that this is the one we should be using now. The installation script complains that `ynh_substitute_char` doesn't exist anymore.